### PR TITLE
Bump python-broadlink to 0.15.0

### DIFF
--- a/custom_components/floureon/manifest.json
+++ b/custom_components/floureon/manifest.json
@@ -5,5 +5,5 @@
   "dependencies": [],
   "codeowners": ["@algirdasc"],
   "issue_tracker": "https://github.com/algirdasc/hass-floureon/issues",
-  "requirements": ["pythoncrc", "broadlink==0.14.1"]
+  "requirements": ["pythoncrc", "broadlink>=0.15.0"]
 }


### PR DESCRIPTION
fixes https://github.com/algirdasc/hass-floureon/issues/5 https://github.com/home-assistant/core/issues/40191#issuecomment-706528580

I suggest the adoption of `>=` in the manifest, eg. `broadlink>=0.15.0`, so this component doesn't prevent users from updating the library in Home Assistant.