### PR TITLE
Climate method warnings fix

### DIFF
--- a/custom_components/floureon/climate.py
+++ b/custom_components/floureon/climate.py
@@ -51,7 +51,7 @@ from homeassistant.const import (
     PRECISION_WHOLE,
     PRECISION_TENTHS,
     ATTR_TEMPERATURE,
-    TEMP_CELSIUS,
+    UnitOfTemperature,
     CONF_NAME
 )
 
@@ -125,7 +125,7 @@ class FloureonClimate(ClimateEntity, RestoreEntity):
     @property
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def hvac_mode(self) -> str:
@@ -192,13 +192,13 @@ class FloureonClimate(ClimateEntity, RestoreEntity):
     @property
     def min_temp(self) -> float:
         """Return the minimum temperature."""
-        return self.get_converter()(self._min_temp, TEMP_CELSIUS,
+        return self.get_converter()(self._min_temp, UnitOfTemperature.CELSIUS,
                                     self.temperature_unit)
 
     @property
     def max_temp(self) -> float:
         """Return the maximum temperature."""
-        return self.get_converter()(self._max_temp, TEMP_CELSIUS,
+        return self.get_converter()(self._max_temp, UnitOfTemperature.CELSIUS,
                                     self.temperature_unit)
 
     @property

--- a/custom_components/floureon/climate.py
+++ b/custom_components/floureon/climate.py
@@ -78,6 +78,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 class FloureonClimate(ClimateEntity, RestoreEntity):
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, hass, config):
         self._hass = hass
@@ -178,7 +179,7 @@ class FloureonClimate(ClimateEntity, RestoreEntity):
     @property
     def supported_features(self):
         """Return the list of supported features."""
-        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
 
     # Backward compatibility until 2023.4
     def get_converter(self):


### PR DESCRIPTION
To fix warning as:

Entity None (<class 'custom_components.floureon.climate.FloureonClimate'>) does not set ClimateEntityFeature.TURN_OFF but implements the turn_off method. Please create a bug report at https://github.com/algirdasc/hass-floureon/issues
Entity None (<class 'custom_components.floureon.climate.FloureonClimate'>) does not set ClimateEntityFeature.TURN_ON but implements the turn_on method. Please create a bug report at https://github.com/algirdasc/hass-floureon/issues
Entity None (<class 'custom_components.floureon.climate.FloureonClimate'>) implements HVACMode(s): auto, heat, off and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature. Please create a bug report at https://github.com/algirdasc/hass-floureon/issues


More about the issue: https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/